### PR TITLE
Move Username Picking To Registration Process

### DIFF
--- a/app/Controllers/Http/AuthController.ts
+++ b/app/Controllers/Http/AuthController.ts
@@ -27,22 +27,31 @@ export default class AuthController {
     });
 
     if (usernameExists) {
-      return response.notAcceptable({ error: 'Username already taken' });
+      return response.notAcceptable({
+        error: 'Username already taken',
+        errorCode: 'USERNAME_TAKEN',
+      });
     }
 
-    const { data, error } = await supabase.auth.signUp({
+    const { data, error: supabaseSignupError } = await supabase.auth.signUp({
       email,
       password,
     });
 
-    if (error) {
-      return response.send(error);
+    if (supabaseSignupError) {
+      return response.badRequest({
+        error: supabaseSignupError.message,
+        errorCode: supabaseSignupError.name,
+      });
     }
 
     const { session, user } = data;
 
     if (!session || !user) {
-      return response.badRequest({ error: 'Sign up failed' });
+      return response.badRequest({
+        error: 'Sign up failed',
+        errorCode: 'SIGNUP_FAILED',
+      });
     }
     const access_token = session?.access_token;
     const refresh_token = session?.refresh_token;


### PR DESCRIPTION
# Goal

User will be able to pick and see if their chosen username is available during registration / account creation

# AC

- [x] Include username field in registration api
- [x] Return error if username taken

- validate username field
- query database to see if username is taken
- return error if taken
- continue account and profile creation if not taken -