### PR TITLE
Wip/31 enhance standardize error responses

### DIFF
--- a/app/Controllers/Http/ApikeysController.ts
+++ b/app/Controllers/Http/ApikeysController.ts
@@ -52,7 +52,7 @@ export default class ApikeysController {
         },
       });
 
-      return response.json({
+      return response.ok({
         apiKey: plainKey,
         apikeyId: result.id,
         domain,
@@ -73,7 +73,7 @@ export default class ApikeysController {
         },
       });
 
-      return response.json({
+      return response.ok({
         apiKey: plainKey,
         apikeyId: result.id,
         domain,
@@ -140,7 +140,7 @@ export default class ApikeysController {
 
     const decryptedApikey = Encryption.decrypt(apikey.key);
 
-    return response.json({
+    return response.ok({
       ...apikey,
       apiKey: decryptedApikey,
       apikeyId: apikey.id,

--- a/app/Controllers/Http/AuthController.ts
+++ b/app/Controllers/Http/AuthController.ts
@@ -77,7 +77,7 @@ export default class AuthController {
     return response.ok({ user: userData, access_token });
   }
 
-  public async login({ request, response }) {
+  public async login({ request, response }: HttpContextContract) {
     const { email, password } = request.body();
     await request.validate({ schema: loginSchema });
 
@@ -88,7 +88,6 @@ export default class AuthController {
 
     if (error) {
       throw new AuthException(error.name, undefined, error.message);
-      return response.send(error);
     }
 
     const { session, user } = data;
@@ -124,10 +123,11 @@ export default class AuthController {
       secure: Env.get('NODE_ENV') === 'production' ? true : false,
       sameSite: Env.get('NODE_ENV') === 'production' ? 'none' : 'lax',
     });
-    return { user: userData, access_token };
+
+    return response.ok({ user: userData, access_token });
   }
 
-  public async logout({ request }) {
+  public async logout({ request, response }: HttpContextContract) {
     const access_token = request.access_token;
     const { error } = await supabase.auth.signOut(access_token);
 
@@ -136,7 +136,9 @@ export default class AuthController {
     }
 
     if (!error) {
-      return { loggedOut: true };
+      return response.clearCookie(refreshTokenCookieName).ok({
+        loggedOut: true,
+      });
     }
   }
 

--- a/app/Controllers/Http/AuthController.ts
+++ b/app/Controllers/Http/AuthController.ts
@@ -151,6 +151,7 @@ export default class AuthController {
 
     if (error) {
       response.send(error);
+      throw new AuthException(error.name, undefined, error.message);
     }
 
     const { session } = data;
@@ -163,7 +164,8 @@ export default class AuthController {
       secure: Env.get('NODE_ENV') === 'production' ? true : false,
       sameSite: Env.get('NODE_ENV') === 'production' ? 'none' : 'lax',
     });
-    return { access_token };
+
+    return response.ok({ access_token });
   }
 
   public async deleteAccount({ request, response }: HttpContextContract) {
@@ -174,7 +176,12 @@ export default class AuthController {
       await supabase.auth.admin.deleteUser(userId);
 
     if (supabaseError) {
-      return response.badRequest({ supabaseError });
+      response.badRequest({ supabaseError });
+      throw new AuthException(
+        supabaseError.name,
+        undefined,
+        supabaseError.message
+      );
     }
 
     if (Object.keys(userData.user).length) {

--- a/app/Controllers/Http/ProjectsController.ts
+++ b/app/Controllers/Http/ProjectsController.ts
@@ -1,13 +1,13 @@
-// import type { HttpContextContract } from "@ioc:Adonis/Core/HttpContext";
-import { Project } from '@prisma/client'
-import prisma from '../../../prisma/prisma'
-import ProjectException from '../../Exceptions/ProjectException'
-import { schema } from '@ioc:Adonis/Core/Validator'
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+import { Project } from '@prisma/client';
+import prisma from '../../../prisma/prisma';
+import ProjectException from '../../Exceptions/ProjectException';
+import { schema } from '@ioc:Adonis/Core/Validator';
 
 export default class ProjectsController {
-  async createProjects ({ request }) {
-    const { projects } = request.body()
-    const user_id = request.authenticatedUser.id
+  async createProjects({ request, response }: HttpContextContract) {
+    const { projects } = request.body();
+    const user_id = request.authenticatedUser.id;
 
     // projects object input validation schema
     const newProjectsSchema = schema.create({
@@ -18,7 +18,7 @@ export default class ProjectsController {
           project_url: schema.string(),
         })
       ),
-    })
+    });
 
     const userProfile = await prisma.userProfile.findUnique({
       where: {
@@ -27,36 +27,36 @@ export default class ProjectsController {
       include: {
         projects: true,
       },
-    })
+    });
 
     if (!userProfile) {
-      const message = 'User profile must be created first'
-      const status = 404
-      const errorCode = 'UserProfileNotFound'
+      const message = 'User profile must be created first';
+      const status = 404;
+      const errorCode = 'UserProfileNotFound';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
-    await request.validate({ schema: newProjectsSchema })
+    await request.validate({ schema: newProjectsSchema });
 
     // if more than 2, do not allow
-    let freeTierLimit
-    const userProjectsCount = userProfile.projects.length
+    let freeTierLimit;
+    const userProjectsCount = userProfile.projects.length;
 
     if (userProfile.membership === 'BASIC') {
-      freeTierLimit = 1
+      freeTierLimit = 1;
     }
     if (userProfile.membership === 'PRO') {
-      freeTierLimit = 3
+      freeTierLimit = 3;
     }
 
     // const limitRemainder = freeTierLimit - userProjectsCount
     if (userProjectsCount >= freeTierLimit) {
-      const message = 'You have exceeded the number of projects allowed'
-      const status = 403
-      const errorCode = 'FreeTierLimit'
+      const message = 'You have exceeded the number of projects allowed';
+      const status = 403;
+      const errorCode = 'FreeTierLimit';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const data = projects.map((project: Project) => {
@@ -64,8 +64,8 @@ export default class ProjectsController {
         ...project,
         user_id,
         username: userProfile.username,
-      }
-    })
+      };
+    });
 
     const createdProjects = await Promise.all(
       data.map(async (project: Project) => {
@@ -78,17 +78,17 @@ export default class ProjectsController {
             project_description: true,
             project_url: true,
           },
-        })
+        });
       })
-    )
+    );
 
-    return {
+    return response.ok({
       projects: createdProjects,
-    }
+    });
   }
 
-  async getOwnProjects ({ request }) {
-    const user_id = request.authenticatedUser.id
+  async getOwnProjects({ request, response }: HttpContextContract) {
+    const user_id = request.authenticatedUser.id;
 
     const ownProjects = await prisma.project.findMany({
       where: {
@@ -101,29 +101,29 @@ export default class ProjectsController {
         project_description: true,
         username: true,
       },
-    })
+    });
 
-    return {
+    return response.ok({
       projects: ownProjects,
-    }
+    });
   }
 
-  async updateProjectById ({ request }) {
-    const user_id = request.authenticatedUser.id
-    const { id, ...updateProject } = request.body().updateProject
+  async updateProjectById({ request, response }: HttpContextContract) {
+    const user_id = request.authenticatedUser.id;
+    const { id, ...updateProject } = request.body().updateProject;
 
     const userProfile = await prisma.userProfile.findUnique({
       where: {
         user_id,
       },
-    })
+    });
 
     if (!userProfile) {
-      const message = 'User profile must be created first'
-      const status = 404
-      const errorCode = 'UserProfileNotFound'
+      const message = 'User profile must be created first';
+      const status = 404;
+      const errorCode = 'UserProfileNotFound';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const updatedProject = await prisma.project.update({
@@ -139,84 +139,84 @@ export default class ProjectsController {
         project_description: true,
         username: true,
       },
-    })
+    });
 
-    return {
+    return response.ok({
       updatedProject,
-    }
+    });
   }
 
-  async deleteById ({ request }) {
-    const user_id = request.authenticatedUser.id
-    const { projectId } = request.params()
-    const { project } = request.body()
+  async deleteById({ request, response }: HttpContextContract) {
+    const user_id = request.authenticatedUser.id;
+    const { projectId } = request.params();
+    const { project } = request.body();
 
     if (!project) {
-      const message = 'Please select projects to delete'
-      const status = 400
-      const errorCode = 'ProjectSelectionError'
+      const message = 'Please select projects to delete';
+      const status = 400;
+      const errorCode = 'ProjectSelectionError';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const matchedUser = await prisma.userProfile.findUnique({
       where: {
         user_id,
       },
-    })
+    });
 
     if (!matchedUser) {
-      const message = 'Invalid credentials'
-      const status = 400
-      const errorCode = 'InvalidCredentials'
+      const message = 'Invalid credentials';
+      const status = 400;
+      const errorCode = 'InvalidCredentials';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const deletedProject = await prisma.project.delete({
       where: {
         id: projectId,
       },
-    })
+    });
 
     if (!deletedProject) {
-      const message = 'Items to be deleted were not found'
-      const status = 404
-      const errorCode = 'ItemsNotFound'
+      const message = 'Items to be deleted were not found';
+      const status = 404;
+      const errorCode = 'ItemsNotFound';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
-    return {
+    return response.ok({
       deleted: true,
       project: deletedProject,
-    }
+    });
   }
 
-  async deleteProjectByIds ({ request }) {
-    const user_id = request.authenticatedUser.id
-    const { projectsToDelete } = request.body()
+  async deleteProjectByIds({ request, response }: HttpContextContract) {
+    const user_id = request.authenticatedUser.id;
+    const { projectsToDelete } = request.body();
 
     if (!projectsToDelete.length) {
-      const message = 'Please select projects to delete'
-      const status = 400
-      const errorCode = 'ProjectSelectionError'
+      const message = 'Please select projects to delete';
+      const status = 400;
+      const errorCode = 'ProjectSelectionError';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const matchedUser = await prisma.userProfile.findUnique({
       where: {
         user_id,
       },
-    })
+    });
 
     if (!matchedUser) {
-      const message = 'Invalid credentials'
-      const status = 400
-      const errorCode = 'InvalidCredentials'
+      const message = 'Invalid credentials';
+      const status = 400;
+      const errorCode = 'InvalidCredentials';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
     const deletedProjects = await prisma.project.deleteMany({
@@ -225,16 +225,16 @@ export default class ProjectsController {
           in: projectsToDelete,
         },
       },
-    })
+    });
 
     if (!deletedProjects.count) {
-      const message = 'Items to be deleted were not found'
-      const status = 404
-      const errorCode = 'ItemsNotFound'
+      const message = 'Items to be deleted were not found';
+      const status = 404;
+      const errorCode = 'ItemsNotFound';
 
-      throw new ProjectException(message, status, errorCode)
+      throw new ProjectException(message, status, errorCode);
     }
 
-    return { deletedProjects }
+    return response.ok({ deletedProjects });
   }
 }

--- a/app/Controllers/Http/UserProfileController.ts
+++ b/app/Controllers/Http/UserProfileController.ts
@@ -1,9 +1,9 @@
 import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
 import prisma from '../../../prisma/prisma';
 import { schema, rules, validator } from '@ioc:Adonis/Core/Validator';
+import UserProfileException from '../../Exceptions/UserProfileException';
 
 const CreateUserProfileSchema = schema.create({
-  username: schema.string(),
   firstName: schema.string(),
   lastName: schema.string(),
 });
@@ -11,7 +11,7 @@ const CreateUserProfileSchema = schema.create({
 export default class UserProfileController {
   async create({ request, response }: HttpContextContract) {
     const { id, email } = request.authenticatedUser;
-    const { username, firstName, lastName } = request.body();
+    const { firstName, lastName } = request.body();
 
     await validator.validate({
       schema: schema.create({
@@ -31,7 +31,6 @@ export default class UserProfileController {
         user_id: id,
       },
       data: {
-        username,
         firstName,
         lastName,
       },
@@ -75,7 +74,7 @@ export default class UserProfileController {
     return { data: userProfile };
   }
 
-  protected async getMyProfile({ request }) {
+  protected async getMyProfile({ request, response }: HttpContextContract) {
     const auth_user_id = request.authenticatedUser.id;
 
     await validator.validate({
@@ -101,7 +100,7 @@ export default class UserProfileController {
       },
     });
 
-    return { data: userProfile };
+    return response.ok({ data: userProfile });
   }
 
   protected async getMyJSONProfile({ request, response }: HttpContextContract) {
@@ -120,10 +119,10 @@ export default class UserProfileController {
       return response.notFound({ error: 'Something went wrong.' });
     }
 
-    return { userProfile };
+    return response.ok({ userProfile });
   }
 
-  async deleteUserProfile({ request }) {
+  async deleteUserProfile({ request, response }: HttpContextContract) {
     const { username } = request.params();
     const auth_user_id = request.authenticatedUser.id;
 
@@ -150,6 +149,6 @@ export default class UserProfileController {
       },
     });
 
-    return { data: deletedUserProfile };
+    return response.ok({ data: deletedUserProfile });
   }
 }

--- a/app/Controllers/Http/UserProfileController.ts
+++ b/app/Controllers/Http/UserProfileController.ts
@@ -149,6 +149,6 @@ export default class UserProfileController {
       },
     });
 
-    return response.ok({ data: deletedUserProfile });
+    return response.accepted({ data: deletedUserProfile });
   }
 }

--- a/app/Exceptions/AuthException.ts
+++ b/app/Exceptions/AuthException.ts
@@ -1,0 +1,42 @@
+import { Exception } from '@adonisjs/core/build/standalone';
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+
+/*
+|--------------------------------------------------------------------------
+| Exception
+|--------------------------------------------------------------------------
+|
+| The Exception class imported from `@adonisjs/core` allows defining
+| a status code and error code for every exception.
+|
+| @example
+| new AuthException('message', 500, 'E_RUNTIME_EXCEPTION')
+|
+*/
+export enum AuthErrorCode {
+  USERNAME_TAKEN = 'USERNAME_TAKEN',
+  SIGNUP_FAILED = 'SIGNUP_FAILED',
+}
+export default class AuthException extends Exception {
+  private static messages: Record<AuthErrorCode, string> = {
+    [AuthErrorCode.USERNAME_TAKEN]: 'Username already taken',
+    [AuthErrorCode.SIGNUP_FAILED]: 'Sign up failed',
+  };
+
+  constructor(
+    errorCode: AuthErrorCode | string,
+    status?: number,
+    message?: string
+  ) {
+    const errorMessage = AuthException.messages[errorCode] ?? message;
+    super(errorMessage, (status = 400));
+    this.code = errorCode;
+  }
+
+  public async handle(error: this, { response }: HttpContextContract) {
+    response.status(error.status).json({
+      error: error.message,
+      errorCode: error.code || 'UNKNOWN_ERROR',
+    });
+  }
+}

--- a/app/Exceptions/AuthException.ts
+++ b/app/Exceptions/AuthException.ts
@@ -17,6 +17,7 @@ export enum AuthErrorCode {
   USERNAME_TAKEN = 'USERNAME_TAKEN',
   SIGNUP_FAILED = 'SIGNUP_FAILED',
 }
+
 export default class AuthException extends Exception {
   private static messages: Record<AuthErrorCode, string> = {
     [AuthErrorCode.USERNAME_TAKEN]: 'Username already taken',

--- a/app/Exceptions/Handler.ts
+++ b/app/Exceptions/Handler.ts
@@ -1,4 +1,4 @@
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
 /*
 |--------------------------------------------------------------------------
 | Http Exception Handler
@@ -14,49 +14,49 @@ import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 |
 */
 
-import Logger from '@ioc:Adonis/Core/Logger'
-import HttpExceptionHandler from '@ioc:Adonis/Core/HttpExceptionHandler'
-import { Prisma } from '@prisma/client'
+import Logger from '@ioc:Adonis/Core/Logger';
+import HttpExceptionHandler from '@ioc:Adonis/Core/HttpExceptionHandler';
+import { Prisma } from '@prisma/client';
 
 export default class ExceptionHandler extends HttpExceptionHandler {
-  constructor () {
-    super(Logger)
+  constructor() {
+    super(Logger);
   }
 
-  async handle (error: any, { response }: HttpContextContract) {
-    console.log('ERROR: ', error)
+  async handle(error: any, { response }: HttpContextContract) {
+    console.log('ERROR: ', error);
 
     if (error.name === 'ValidationException') {
-      return response.status(200).json({ error: error.messages.errors })
+      return response.status(200).json({ error: error.messages.errors });
     }
 
     if (error.name === 'AuthApiError') {
       if (error.message.includes('invalid claim')) {
-        return response.status(error.status).json({ error: 'Please log in' })
+        return response.status(error.status).json({ error: 'Please log in' });
       }
 
       if (error.message.includes('invalid JWT')) {
         return response
           .status(error.status)
-          .json({ error: 'Invalid credentials' })
+          .json({ error: 'Invalid credentials' });
       }
 
-      return response.status(error.status).json({ error: error.message })
+      return response.status(error.status).json({ error: error.message });
     }
 
     if (error.message === 'Unauthorized') {
-      return response.status(403).json({ error: 'Invalid credentials' })
+      return response.status(403).json({ error: 'Invalid credentials' });
     }
 
     if (error.message === 'ProfileDeletionError') {
       return response.status(400).json({
         error: 'Cannot find user profile',
-      })
+      });
     }
     if (error.message === 'ProfileDoesNotExist') {
       return response.status(404).json({
         error: 'User profile does not exist',
-      })
+      });
     }
 
     // MEMBERSHIP ERRORS
@@ -73,17 +73,18 @@ export default class ExceptionHandler extends HttpExceptionHandler {
         case 'P2002':
           return response.status(400).json({
             error: `${error.meta.target[0]} is already taken`,
-          })
+          });
         case 'P2025':
           return response.status(404).json({
-            error: error.meta,
+            error: 'User profile record not found',
+            errorCode: 'PROFILE_NOT_FOUND',
             // error: "User profile does not exist",
-          })
+          });
         default:
-          return response.status(500).json({ error: 'Internal server error' })
+          return response.status(500).json({ error: 'Internal server error' });
       }
     }
 
-    return super.handle(error, { response } as HttpContextContract)
+    return super.handle(error, { response } as HttpContextContract);
   }
 }

--- a/app/Exceptions/ProjectException.ts
+++ b/app/Exceptions/ProjectException.ts
@@ -1,5 +1,5 @@
-import { Exception } from '@adonisjs/core/build/standalone'
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { Exception } from '@adonisjs/core/build/standalone';
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
 
 /*
 |--------------------------------------------------------------------------
@@ -14,9 +14,9 @@ import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 |
 */
 export default class ProjectException extends Exception {
-  public async handle (error: this, { response }: HttpContextContract) {
+  public async handle(error: this, { response }: HttpContextContract) {
     return response
       .status(error.status)
-      .json({ error: error.message, errorCode: error.code })
+      .json({ error: error.message, errorCode: error.code });
   }
 }

--- a/app/Exceptions/UserProfileException.ts
+++ b/app/Exceptions/UserProfileException.ts
@@ -1,0 +1,22 @@
+import { Exception } from '@adonisjs/core/build/standalone';
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+
+/*
+|--------------------------------------------------------------------------
+| Exception
+|--------------------------------------------------------------------------
+|
+| The Exception class imported from `@adonisjs/core` allows defining
+| a status code and error code for every exception.
+|
+| @example
+| new UserProfileException('message', 500, 'E_RUNTIME_EXCEPTION')
+|
+*/
+export default class UserProfileException extends Exception {
+  public async handle(error: this, { response }: HttpContextContract) {
+    return response
+      .status(error.status)
+      .json({ error: error.message, errorCode: error.code });
+  }
+}


### PR DESCRIPTION
# Goal

Standardize Error Responses like so:

`response.[badRequest, etc]({
 error: string,
errorCode: STRING_STRING
})`

# AC

- [x] Register route
- [x] Auth controller
- [x] projects controller
- [x] userprofile controller
- [x] apikeys controller